### PR TITLE
Compute Severity & Tag correctly. Fix #1.

### DIFF
--- a/build/packet.js
+++ b/build/packet.js
@@ -91,5 +91,5 @@ exports.create = function(options) {
   if (Buffer.byteLength(options.serial, 'utf8') > 31) {
     throw new Error('Serial byte limit is 31');
   }
-  return msgpack.encode([PACKET_VERSION, options.severity << options.tag, options.productKey, options.serial, options.message]);
+  return msgpack.encode([PACKET_VERSION, (options.severity << 5) + options.tag, options.productKey, options.serial, options.message]);
 };

--- a/lib/packet.coffee
+++ b/lib/packet.coffee
@@ -89,7 +89,7 @@ exports.create = (options) ->
 
 	return msgpack.encode [
 		PACKET_VERSION
-		options.severity << options.tag
+		(options.severity << 5) + options.tag
 		options.productKey
 		options.serial
 		options.message

--- a/tests/packet.spec.coffee
+++ b/tests/packet.spec.coffee
@@ -145,7 +145,7 @@ describe 'Packet:', ->
 			decoded = msgpack.decode(payload)
 			m.chai.expect(decoded[0]).to.equal(1)
 
-		it 'should compute a severity and tag of 001100000 given 3 and 5', ->
+		it 'should compute a severity and tag of 001100101 given 3 and 5', ->
 			payload = packet.create
 				severity: 3
 				tag: 5
@@ -154,7 +154,7 @@ describe 'Packet:', ->
 				serial: '1234'
 
 			decoded = msgpack.decode(payload)
-			m.chai.expect(decoded[1]).to.equal(parseInt('001100000', 2))
+			m.chai.expect(decoded[1]).to.equal(parseInt('001100101', 2))
 
 		it 'should put the product key as the third item in the array', ->
 			payload = packet.create


### PR DESCRIPTION
It was currently being computer as:

	severity << tag

However the correct approach is:

	(severity << 5) + tag