### PR TITLE
Increase serial length constraint to 64 characters

### DIFF
--- a/build/packet.js
+++ b/build/packet.js
@@ -88,8 +88,8 @@ exports.create = function(options) {
   if (!_.isString(options.serial)) {
     throw new Error('Serial should be a string');
   }
-  if (Buffer.byteLength(options.serial, 'utf8') > 31) {
-    throw new Error('Serial byte limit is 31');
+  if (options.serial.length > 64) {
+    throw new Error('Serial length limit is 64');
   }
   return msgpack.encode([PACKET_VERSION, (options.severity << 5) + options.tag, options.productKey, options.serial, options.message]);
 };

--- a/lib/packet.coffee
+++ b/lib/packet.coffee
@@ -84,8 +84,8 @@ exports.create = (options) ->
 	if not _.isString(options.serial)
 		throw new Error('Serial should be a string')
 
-	if Buffer.byteLength(options.serial, 'utf8') > 31
-		throw new Error('Serial byte limit is 31')
+	if options.serial.length > 64
+		throw new Error('Serial length limit is 64')
 
 	return msgpack.encode [
 		PACKET_VERSION

--- a/tests/packet.spec.coffee
+++ b/tests/packet.spec.coffee
@@ -113,15 +113,15 @@ describe 'Packet:', ->
 					serial: 1234
 			.to.throw('Serial should be a string')
 
-		it 'should throw if serial has more than 31 characters', ->
+		it 'should throw if serial has more than 64 characters', ->
 			m.chai.expect ->
 				packet.create
 					severity: 1
 					tag: 0
 					message: 'Hello World'
 					productKey: '8ygh638f3nn2937t'
-					serial: 'abcdefghijklmnopqrstuvwxyz012345'
-			.to.throw('Serial byte limit is 31')
+					serial: _.str.repeat('12345678', 8) + '0'
+			.to.throw('Serial length limit is 64')
 
 		it 'should encode an array of length 5', ->
 			payload = packet.create


### PR DESCRIPTION
Crow's Nest C library imposes a 31 byte restriction, however the server
imposes a 64 characters restriction instead.